### PR TITLE
Added Asyncrenderloop class

### DIFF
--- a/src/public/async.h
+++ b/src/public/async.h
@@ -10,7 +10,6 @@
 #include <QObject>
 #include <functional>
 #include "config.h"
-#include "atomicmetatypes.h"
 #include "heart_global.h"
 
 namespace QH {

--- a/src/public/asyncrenderloop.cpp
+++ b/src/public/asyncrenderloop.cpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2025-2025 QuasarApp.
+ * Distributed under the lgplv3 software license, see the accompanying
+ * Everyone is permitted to copy and distribute verbatim copies
+ * of this license document, but changing it is not allowed.
+*/
+
+#include "asyncrenderloop.h"
+#include <QDateTime>
+#include <QThread>
+
+namespace QH {
+
+AsyncRenderLoop::AsyncRenderLoop(QThread *thread, QObject *ptr): Async(thread, ptr) {
+
+}
+
+void QH::AsyncRenderLoop::run() {
+    m_run = true;
+    asyncLauncher([this](){
+        renderLoopPrivate();
+        return true;
+    });
+}
+
+void QH::AsyncRenderLoop::stop() {
+    m_run = false;
+    thread()->exit();
+    thread()->wait();
+}
+
+bool AsyncRenderLoop::isRun() const {
+    return m_run || (thread() && thread()->isRunning());
+}
+
+void QH::AsyncRenderLoop::renderLoopPrivate() {
+    quint64 currentTime = QDateTime::currentMSecsSinceEpoch();
+
+    _lastIterationTime = currentTime;
+    int iterationTime = 0;
+
+    while (m_run) {
+        renderIteration(iterationTime);
+
+        currentTime = QDateTime::currentMSecsSinceEpoch();
+        iterationTime = currentTime - _lastIterationTime;
+        _lastIterationTime = currentTime;
+    }
+}
+
+} // namespace QH

--- a/src/public/asyncrenderloop.h
+++ b/src/public/asyncrenderloop.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2025-2025 QuasarApp.
+ * Distributed under the lgplv3 software license, see the accompanying
+ * Everyone is permitted to copy and distribute verbatim copies
+ * of this license document, but changing it is not allowed.
+*/
+
+#ifndef ASYNCRENDERLOOP_H
+#define ASYNCRENDERLOOP_H
+
+#include "async.h"
+
+namespace QH {
+
+/**
+ * @brief The AsyncRenderLoop class is a class for rendering the world.
+ */
+class HEARTSHARED_EXPORT AsyncRenderLoop: public Async
+{
+    Q_OBJECT
+public:
+    AsyncRenderLoop(QThread* thread, QObject* ptr = nullptr);
+
+    /**
+     * @brief run This method starts the render loop.
+     */
+    virtual void run();
+
+    /**
+     * @brief stop This method stops the render loop.
+     */
+    virtual void stop();
+
+    /**
+     * @brief isRun This method returns the state of the render loop.
+     * @return true if the render loop is running, else false.
+     */
+    bool isRun() const;
+
+protected:
+
+    /**
+     * @brief renderIteration This method is called in each iteration of the render loop.
+     * This method must be implemented in the derived class.
+     * @param msec time in milliseconds from the last iteration.
+     * @see stop
+     * @see run
+     */
+    virtual void renderIteration(int msec) = 0;
+
+private slots:
+    void renderLoopPrivate();
+
+private:
+    bool m_run = false;
+    quint64 _lastIterationTime = 0;
+
+};
+}
+#endif // ASYNCRENDERLOOP_H

--- a/src/public/asyncrenderloop.h
+++ b/src/public/asyncrenderloop.h
@@ -13,7 +13,28 @@
 namespace QH {
 
 /**
- * @brief The AsyncRenderLoop class is a class for rendering the world.
+ * @brief The AsyncRenderLoop is a class for asynchronous rendering.
+ * This class is used to create a render loop that is executed in a separate thread.
+ * To use this class, you must inherit from it and implement the renderIteration method.
+ * @example :
+ * @code{cpp}
+ * class MyRenderLoop: public AsyncRenderLoop
+ * {
+ * public:
+ *    MyRenderLoop(QThread* thread, QObject* ptr = nullptr): AsyncRenderLoop(thread, ptr) {}
+ *    void renderIteration(int msec) override {
+ *    // your code here
+ *    }
+ * };
+ * int main (int argc, char* argv[]) {
+ *    QCoreApplication app(argc, argv);
+ *
+ *    MyRenderLoop loop(new thread());
+ *    loop.run();
+ *    loop.stop();
+ *
+ *    return app.exec();
+ * @endcode
  */
 class HEARTSHARED_EXPORT AsyncRenderLoop: public Async
 {


### PR DESCRIPTION

The AsyncRenderLoop is a class for asynchronous rendering.
This class is used to create a render loop that is executed in a separate thread.
To use this class, you must inherit from it and implement the renderIteration method.

``` cpp 
 class MyRenderLoop: public AsyncRenderLoop
 {
 public:
     MyRenderLoop(QThread* thread, QObject* ptr = nullptr): AsyncRenderLoop(thread, ptr) {}
     void renderIteration(int msec) override {
     // your code here
     }
  };
  int main (int argc, char* argv[]) {
     QCoreApplication app(argc, argv);
 
     MyRenderLoop loop(new thread());
     loop.run();
     loop.stop();
 
     return app.exec();
  }
```
